### PR TITLE
Introduce dynamic (altered by app)  libraries

### DIFF
--- a/se_module/springboot.fc
+++ b/se_module/springboot.fc
@@ -32,7 +32,12 @@
 /var/run/springboot(/.*)?							gen_context(system_u:object_r:springboot_run_t,s0)
 /var/tmp/springboot(/.*)?							gen_context(system_u:object_r:springboot_tmp_t,s0)
 /var/lib/springboot(/.*)?							gen_context(system_u:object_r:springboot_var_t,s0)
+#
 /srv/springboot(/.*)?								gen_context(system_u:object_r:springboot_var_t,s0)
+/srv/springboot/(.*/)?te?mp(/.*)?						gen_context(system_u:object_r:springboot_tmp_t,s0)
+/srv/springboot/(.*/)?(cache|run|work)(/.*)?					gen_context(system_u:object_r:springboot_run_t,s0)
+/srv/springboot/(.*/)?(d?lib|app)(/.*)?						gen_context(system_u:object_r:springboot_dynlib_t,s0)
+/srv/springboot/(.*/)?.*\.(so|jar)([\.p-][0-9]+)*			--	gen_context(system_u:object_r:springboot_dynlib_t,s0)
 #
 /opt/springboot/bin/springboot_service					--	gen_context(system_u:object_r:springboot_exec_t,s0)
 /opt/springboot/service/.*						--	gen_context(system_u:object_r:springboot_exec_t,s0)

--- a/se_module/springboot.fc
+++ b/se_module/springboot.fc
@@ -36,7 +36,7 @@
 /srv/springboot(/.*)?								gen_context(system_u:object_r:springboot_var_t,s0)
 /srv/springboot/(.*/)?te?mp(/.*)?						gen_context(system_u:object_r:springboot_tmp_t,s0)
 /srv/springboot/(.*/)?(cache|run|work)(/.*)?					gen_context(system_u:object_r:springboot_run_t,s0)
-/srv/springboot/(.*/)?(d?lib|app)(/.*)?						gen_context(system_u:object_r:springboot_dynlib_t,s0)
+/srv/springboot/(.*/)?dyn(lib|app)(/.*)?					gen_context(system_u:object_r:springboot_dynlib_t,s0)
 /srv/springboot/(.*/)?.*\.(so|jar)([\.p-][0-9]+)*			--	gen_context(system_u:object_r:springboot_dynlib_t,s0)
 #
 /opt/springboot/bin/springboot_service					--	gen_context(system_u:object_r:springboot_exec_t,s0)

--- a/se_module/springboot.te
+++ b/se_module/springboot.te
@@ -87,7 +87,7 @@ files_tmp_file(springboot_tmp_t)
 type		springboot_unit_file_t;
 systemd_unit_file(springboot_unit_file_t);
 
-bool	allow_springboot_dynamic_libs	false;
+bool	allow_springboot_dynamic_libs		false;
 bool	allow_springboot_purge_logs		false;
 bool	allow_webadm_read_springboot_files	false;
 bool	allow_sysadm_write_springboot_files	false;
@@ -230,12 +230,16 @@ allow	springboot_t	springboot_file_type:lnk_file	read_lnk_file_perms;
 
 allow	springboot_t	springboot_bin_t:file			exec_file_perms;
 allow	springboot_t	springboot_lib_t:file			map;
-allow	springboot_t	springboot_dynlib_t:file		exec_file_perms;
 
 if	(allow_springboot_dynamic_libs)	{
 	allow	springboot_t	springboot_dynlib_t:dir		{ create_dir_perms rw_dir_perms };
 	allow	springboot_t	springboot_dynlib_t:file	manage_file_perms;
+	allow	springboot_t	springboot_dynlib_t:file	exec_file_perms;
 	allow	springboot_t	springboot_dynlib_t:lnk_file	manage_lnk_file_perms;
+
+	filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_dynlib_t,	dir, "lib" )
+	filetrans_add_pattern(springboot_t,	springboot_run_t,	springboot_dynlib_t,	dir, "lib" )
+	filetrans_add_pattern(springboot_t,	springboot_tmp_t,	springboot_dynlib_t,	dir, "lib" )
 	filetrans_add_pattern(springboot_t,	springboot_dynlib_t,	springboot_dynlib_t,	{ dir file lnk_file } )
 }
 
@@ -250,7 +254,6 @@ filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_tmp_t,	dir, "te
 filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "run" )
 filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "cache" )
 filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "work" )
-filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_dynlib_t,	dir, "lib" )
 filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_var_t,	{ dir notdevfile_class_set } )
 
 

--- a/se_module/springboot.te
+++ b/se_module/springboot.te
@@ -24,7 +24,7 @@
 #
 ############################################################################
 
-policy_module(springboot, 0.5.0)
+policy_module(springboot, 0.6.0)
 
 ########################################
 #
@@ -75,6 +75,11 @@ type		springboot_lib_t;
 typeattribute	springboot_lib_t	springboot_file_type;
 files_type(springboot_lib_t)
 
+type		springboot_dynlib_t;
+typeattribute	springboot_dynlib_t	springboot_file_type;
+files_type(springboot_dynlib_t)
+
+
 type		springboot_tmp_t;
 typeattribute	springboot_tmp_t	springboot_file_type;
 files_tmp_file(springboot_tmp_t)
@@ -82,6 +87,7 @@ files_tmp_file(springboot_tmp_t)
 type		springboot_unit_file_t;
 systemd_unit_file(springboot_unit_file_t);
 
+bool	allow_springboot_dynamic_libs	false;
 bool	allow_springboot_purge_logs		false;
 bool	allow_webadm_read_springboot_files	false;
 bool	allow_sysadm_write_springboot_files	false;
@@ -222,15 +228,31 @@ allow	springboot_t	springboot_file_type:dir	list_dir_perms;
 allow	springboot_t	springboot_file_type:file	read_file_perms;
 allow	springboot_t	springboot_file_type:lnk_file	read_lnk_file_perms;
 
-allow	springboot_t	springboot_bin_t:file		exec_file_perms;
-allow	springboot_t	springboot_lib_t:file		map;
+allow	springboot_t	springboot_bin_t:file			exec_file_perms;
+allow	springboot_t	springboot_lib_t:file			map;
+allow	springboot_t	springboot_dynlib_t:file		exec_file_perms;
+
+if	(allow_springboot_dynamic_libs)	{
+	allow	springboot_t	springboot_dynlib_t:dir		{ create_dir_perms rw_dir_perms };
+	allow	springboot_t	springboot_dynlib_t:file	manage_file_perms;
+	allow	springboot_t	springboot_dynlib_t:lnk_file	manage_lnk_file_perms;
+	filetrans_add_pattern(springboot_t,	springboot_dynlib_t,	springboot_dynlib_t,	{ dir file lnk_file } )
+}
 
 allow	springboot_t	springboot_exec_t:file		exec_file_perms;
 
 allow	springboot_t	springboot_var_t:dir		manage_dir_perms;
 allow	springboot_t	springboot_var_t:file		manage_file_perms;
 allow	springboot_t	springboot_var_t:lnk_file	manage_lnk_file_perms;
+
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_tmp_t,	dir, "tmp" )
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_tmp_t,	dir, "temp" )
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "run" )
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "cache" )
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_run_t,	dir, "work" )
+filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_dynlib_t,	dir, "lib" )
 filetrans_add_pattern(springboot_t,	springboot_var_t,	springboot_var_t,	{ dir notdevfile_class_set } )
+
 
 allow	springboot_t	springboot_run_t:dir		manage_dir_perms;
 allow	springboot_t	springboot_run_t:file		manage_file_perms;
@@ -262,9 +284,9 @@ dontaudit	springboot_t	domain:file	getattr;
 ##	Permissions for Sys admins (sysadm_t)
 #
 
-allow	sysadm_t	springboot_file_type:dir	list_dir_perms;
-allow	sysadm_t	springboot_file_type:file	getattr_file_perms;
-allow	sysadm_t	springboot_file_type:lnk_file	read_lnk_file_perms;
+allow	sysadm_t	springboot_file_type:dir			list_dir_perms;
+allow	sysadm_t	springboot_file_type:notdevfile_class_set	getattr;
+allow	sysadm_t	springboot_file_type:lnk_file			read_lnk_file_perms;
 
 allow	sysadm_t	springboot_bin_t:file		exec_file_perms;
 
@@ -273,6 +295,7 @@ allow	sysadm_t	springboot_var_t:file		read_file_perms;
 allow	sysadm_t	springboot_run_t:file		read_file_perms;
 allow	sysadm_t	springboot_tmp_t:file		read_file_perms;
 allow	sysadm_t	springboot_lib_t:file		read_file_perms;
+allow	sysadm_t	springboot_dynlib_t:file	read_file_perms;
 allow	sysadm_t	springboot_log_t:file		read_file_perms;
 allow	sysadm_t	springboot_exec_t:file		read_file_perms;
 
@@ -296,9 +319,9 @@ if	(allow_sysadm_write_springboot_files)	{
 ##	Permissions for Web admins (webadm_t)
 #
 
-allow	webadm_t	springboot_file_type:dir	list_dir_perms;
-allow	webadm_t	springboot_file_type:file	getattr_file_perms;
-allow	webadm_t	springboot_file_type:lnk_file	read_lnk_file_perms;
+allow	webadm_t	springboot_file_type:dir			list_dir_perms;
+allow	webadm_t	springboot_file_type:notdevfile_class_set	getattr;
+allow	webadm_t	springboot_file_type:lnk_file			read_lnk_file_perms;
 
 allow	webadm_t	springboot_unit_file_t:file	read_file_perms;
 allow	webadm_t	springboot_unit_file_t:service	{ stop	start	status };


### PR DESCRIPTION
Create a the specific file type `springboot_dynlib_t` for application libraries that the `springboot_t` domain can be allowed to alter through new boolean `allow_springboot_dynamic_libs`. Adapt file contexts definitions, and file transitions, to resolve #9 .

Signed-off-by: Hubert Quarantel-Colombani <hubert@quarantel.name>