### PR TITLE
49-feature-add-booleans-to-allow-connections-to-main-services

### DIFF
--- a/.github/workflows/validate_selinux_compile.yml
+++ b/.github/workflows/validate_selinux_compile.yml
@@ -26,22 +26,70 @@ env:
 
 jobs:
 
-  compile:
-    name: Validate SELinux code
-
+  compile_centos7:
+    name: Validate SELinux code (CentOS 7)
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - uses: hubertqc/selinux_compile@main
-  
-  semodule_info:
-    name: Get SELinux module informations
-    needs: compile
-      
+      - uses: hubertqc/selinux_compile@centos7
+
+  compile_centos8:
+    name: Validate SELinux code (CentOS 8)
     runs-on: ubuntu-latest
 
-    if: ( github.event_name == 'push' && ( github.ref_name == 'main' || startsWith(github.ref_name, 'release/') ) )
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@centos8
+
+  compile_centos9:
+    name: Validate SELinux code (CentOS 9)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@centos9
+
+  compile_fedora34:
+    name: Validate SELinux code (Fedora 34)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@fedora34
+
+
+  compile_fedora35:
+    name: Validate SELinux code (Fedora 35)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@fedora35
+
+  compile_fedora36:
+    name: Validate SELinux code (Fedora 36)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@fedora36
+
+  compile_fedora37:
+    name: Validate SELinux code (Fedora 37)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hubertqc/selinux_compile@fedora37
+
+
+  semodule_info:
+    name: Get SELinux module informations
+    needs: [ compile_centos7, compile_centos8, compile_centos9, compile_fedora34, compile_fedora35, compile_fedora36, compile_fedora37 ]
+      
+    runs-on: ubuntu-latest
     
     permissions:
       actions: read

--- a/README.md
+++ b/README.md
@@ -97,13 +97,25 @@ Examples:
 
 ### SELinux booleans
 
-#### allow_springboot_http_connect      (default: `true`)
+#### allow_springboot_connectto_http      (default: `true`)
 When switch to `true`this boolean allows the Springboot application to connect to remote
 HTTP/HTTPS ports (locally assigned the `http_port_t` SELinux type).
 
-#### allow_springboot_self_connect      (default: `true`)
+#### allow_springboot_connectto_self      (default: `false`)
 When switch to `true`this boolean allows the Springboot application to connect to other remote
 Springboot application (locally assigned the `springboot_port_t` SELinux type).
+
+#### allow_springboot_connectto_ldap      (default: `false`)
+When switch to `true`this boolean allows the Springboot application to connect to remote
+LDAP/LDAPS ports (locally assigned the `ldap_port_t` SELinux type).
+
+#### allow_springboot_connectto_smtp      (default: `false`)
+When switch to `true`this boolean allows the Springboot application to connect to remote
+SMTP/SMTPS/submission ports (locally assigned the `smtp_port_t` SELinux type).
+
+#### Mutiple booleans allow_springboot_connectto_<DB>      (default: `false`)
+When switch to `true`these boolean allows the Springboot application to connect to remote
+database server ports: `couchdb`, `mongodb`, `mysql` (MariaDB), `oracle`, `pgsql` (PostgreSQL), `redis`.
 
 #### allow_springboot_dynamic_libs		(default: `false`)
 When switched to `true`, this boolean allows the Springboot application to create and use

--- a/se_module/springboot.te
+++ b/se_module/springboot.te
@@ -24,7 +24,7 @@
 #
 ############################################################################
 
-policy_module(springboot, 0.6.4)
+policy_module(springboot, 0.7.0)
 
 ########################################
 #
@@ -87,8 +87,19 @@ files_tmp_file(springboot_tmp_t)
 type		springboot_unit_file_t;
 systemd_unit_file(springboot_unit_file_t);
 
-bool	allow_springboot_http_connect		true;
-bool	allow_springboot_self_connect		false;
+bool	allow_springboot_connectto_http		true;
+bool	allow_springboot_connectto_self		false;
+
+bool	allow_springboot_connectto_ldap		false;
+bool	allow_springboot_connectto_smtp		false;
+
+bool	allow_springboot_connectto_oracle	false;
+bool	allow_springboot_connectto_mysql	false;
+bool	allow_springboot_connectto_pgsql	false;
+bool	allow_springboot_connectto_redis	false;
+bool	allow_springboot_connectto_couchdb	false;
+bool	allow_springboot_connectto_mongodb	false;
+
 
 bool	allow_springboot_dynamic_libs		false;
 bool	allow_springboot_purge_logs		false;
@@ -97,6 +108,16 @@ bool	allow_sysadm_write_springboot_files	false;
 
 gen_require(`
 	type	http_port_t;
+	type	smtp_port_t;
+	type	ldap_port_t;
+	type	oracle_port_t;
+	type	mysqld_port_t;
+	type	postgresql_port_t;
+	type	redis_port_t;
+	type	couchdb_port_t;
+	type	mongod_port_t;
+
+
 	type	node_t;
 
 	type	proc_t;
@@ -222,13 +243,47 @@ allow	springboot_t	node_t:tcp_socket			{ node_bind };
 
 allow	springboot_t	springboot_port_t:tcp_socket		name_bind;
 
-if (allow_springboot_http_connect) {
+if (allow_springboot_connectto_http) {
 	allow	springboot_t	http_port_t:tcp_socket		name_connect;
 }
 
-if (allow_springboot_self_connect) {
+if (allow_springboot_connectto_self) {
 	allow	springboot_t	springboot_port_t:tcp_socket	name_connect;
 }
+
+if (allow_springboot_connectto_ldap) {
+	allow	springboot_t	ldap_port_t:tcp_socket	name_connect;
+}
+
+if (allow_springboot_connectto_smtp) {
+	allow	springboot_t	smtp_port_t:tcp_socket	name_connect;
+}
+
+
+if (allow_springboot_connectto_oracle) {
+	allow	springboot_t	oracle_port_t:tcp_socket	name_connect;
+}
+
+if (allow_springboot_connectto_mysql) {
+	allow	springboot_t	mysqld_port_t:tcp_socket	name_connect;	
+}
+
+if (allow_springboot_connectto_pgsql) {
+	allow	springboot_t	postgresql_port_t:tcp_socket	name_connect;
+}
+
+if (allow_springboot_connectto_redis) {
+	allow	springboot_t	redis_port_t:tcp_socket	name_connect;
+}
+
+if (allow_springboot_connectto_couchdb) {
+	allow	springboot_t	couchdb_port_t:tcp_socket	name_connect;
+}
+
+if (allow_springboot_connectto_mongodb) {
+	allow	springboot_t	mongod_port_t:tcp_socket	name_connect;
+}
+
 
 #	Allow to consume authorized network services
 allow	springboot_t	springboot_consumed_svc_type:tcp_socket		name_connect;


### PR DESCRIPTION
Solves #49:
- Introduce SEbooleans for DB connections (Oracle, Redis, PostgreSQL, MysQL/MariaDB, CouchDB, MongoDB) and for LDAP and SMTP connections,
- Rename HTTP and self SEbooleans for naming consistency.

Signed-off-by: Hubert Quarantel-Colombani <hubert@quarantel.name>